### PR TITLE
feat: add go.mod, reformat with gofmt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/shibukawa/extstat
+
+go 1.16


### PR DESCRIPTION
In order to enable this package to work with Go 1.16+, `go.mod` was added and this package was initialized as a go module. Additionally, `gofmt` was run on all of the files.